### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The lib is available on Maven Central, you can find it with [Gradle, please](htt
 
 ```
 dependencies {
-    compile 'co.dift.ui.swipetoaction:library:1.1'
+    implementation 'co.dift.ui.swipetoaction:library:1.1'
 }
 
 ```


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.